### PR TITLE
Refactor response as an object

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: ruby
 
 rvm:
   - "2.0.0"
-  - "2.2.1"
+  - "2.3.1"
 
 notifications:
   email: false

--- a/README.md
+++ b/README.md
@@ -33,7 +33,12 @@ Load a file from cache, or download if needed:
 ```ruby
 require 'webcache'
 cache = WebCache.new
-content = cache.get 'http://example.com'
+response = cache.get 'http://example.com'
+puts response             # => "<html>...</html>"
+puts response.content     # => same as above
+puts response.to_s        # => same as above
+puts response.error       # => nil
+puts response.base_uri    # => "http://example.com/"
 ```
 
 By default, the cached objects are stored in the `./cache` directory, and
@@ -43,7 +48,7 @@ You can change these settings on initialization:
 
 ```ruby
 cache = WebCache.new 'tmp/my_cache', 7200
-content = cache.get 'http://example.com'
+response = cache.get 'http://example.com'
 ```
 
 Or later:
@@ -52,7 +57,7 @@ Or later:
 cache = WebCache.new
 cache.dir = 'tmp/my_cache'
 cache.life = 7200 # seconds
-content = cache.get 'http://example.com'
+response = cache.get 'http://example.com'
 ```
 
 To check if a URL is cached, use the `cached?` method:
@@ -62,7 +67,7 @@ cache = WebCache.new
 cache.cached? 'http://example.com'
 # => false
 
-content = cache.get 'http://example.com'
+response = cache.get 'http://example.com'
 cache.cached? 'http://example.com'
 # => true
 ```
@@ -75,31 +80,41 @@ cache.disable
 cache.enabled? 
 # => false
 
-content = cache.get 'http://example.com'
+response = cache.get 'http://example.com'
 cache.cached? 'http://example.com'
 # => false
 
 cache.enable
-content = cache.get 'http://example.com'
+response = cache.get 'http://example.com'
 cache.cached? 'http://example.com'
 # => true
 ```
 
-Error Handling
+Response Object
 --------------------------------------------------
 
-Whenever a request results in any HTTP error, two things will happen:
+The response object holds these properties:
 
-1. The return value will be set to the error message
-2. The `last_error` variable will be set to the error message
+**`response.content`**:  
+Contains the HTML content. In case of an error, this will include the
+error message. The `#to_s` method of the response object also returns
+the same content.
 
-If `last_error` is anything but `false`, it means failure.
+**`response.error`**:  
+In case of an error, this contains the error message, `nil` otherwose.
+
+**`response.base_uri`**:
+Contains the actual address of the page. This is useful when the request
+is redirected. For example, `http://example.com` will set the 
+`base_uri` to `http://example.com/` (note the trailing slash).
+
 
 ```ruby
 cache = WebCache.new
-puts cache.get 'http://example.com/not_found'
+response = cache.get 'http://example.com/not_found'
+puts response
 # => '404 Not Found'
 
-puts cache.last_error
+puts response.error
 # => '404 Not Found'
 ```

--- a/lib/webcache.rb
+++ b/lib/webcache.rb
@@ -1,2 +1,3 @@
 require 'webcache/version'
 require 'webcache/web_cache'
+require 'webcache/response'

--- a/lib/webcache/response.rb
+++ b/lib/webcache/response.rb
@@ -1,0 +1,21 @@
+class WebCache
+  class Response
+    attr_accessor :error, :base_uri, :content
+
+    def initialize(opts={})
+      if opts.respond_to?(:read) && opts.respond_to?(:base_uri)
+        self.content  = opts.read
+        self.base_uri = opts.base_uri
+        self.error    = nil
+      elsif opts.is_a? Hash
+        self.error    = opts[:error]    if opts[:error]
+        self.base_uri = opts[:base_uri] if opts[:base_uri]
+        self.content  = opts[:content]  if opts[:content]
+      end
+    end
+
+    def to_s
+      content
+    end
+  end
+end

--- a/spec/webcache/response_spec.rb
+++ b/spec/webcache/response_spec.rb
@@ -1,0 +1,55 @@
+require 'spec_helper'
+
+describe WebCache::Response do
+  describe '#new' do
+    context "with hash" do
+      let :response do
+        described_class.new({ 
+          error: 'problemz', 
+          base_uri: 'sky.net', 
+          content: 'robots' 
+        })
+      end
+
+      it "sets error" do
+        expect(response.error).to eq 'problemz'
+      end
+
+      it "sets base_uri" do
+        expect(response.base_uri).to eq 'sky.net'
+      end
+
+      it "sets content" do
+        expect(response.content).to eq 'robots'
+      end
+    end
+
+    context "with open uri" do
+      let :response do
+        described_class.new OpenStruct.new base_uri: 'sky.net', read: 'robots'
+      end
+      
+      it "sets error" do
+        expect(response.error).to be nil
+      end
+
+      it "sets base_uri" do
+        expect(response.base_uri).to eq 'sky.net'
+      end
+
+      it "sets content" do
+        expect(response.content).to eq 'robots'
+      end
+    end
+  end
+
+  describe '#to_s' do
+    let :response do
+      described_class.new content: 'robots'
+    end
+
+    it "returns the content" do
+      expect(response.to_s).to eq 'robots'
+    end
+  end
+end

--- a/spec/webcache/web_cache_spec.rb
+++ b/spec/webcache/web_cache_spec.rb
@@ -57,31 +57,19 @@ describe WebCache do
     it "returns content from cache" do
       cache.get url
       expect(cache).to be_cached url
-      content = cache.get url
-      expect(content.length).to be > 500
+      response = cache.get url
+      expect(response.content.length).to be > 500
     end
 
     context 'with invalid request' do
-      let(:url) { 'http://example.com/not_found' }
+      let(:response) { cache.get 'http://example.com/not_found' }
 
       it 'returns the error message' do
-        expect(cache.get url).to eq '404 Not Found'
+        expect(response.content).to eq '404 Not Found'
       end
 
-      it 'sets last_error to the error message' do
-        cache.get url
-        expect(cache.last_error).to eq '404 Not Found'
-      end
-    end
-
-    context 'with a valid request following an invalid one' do
-      let(:invalid_url) { 'http://example.com/not_found' }
-
-      it 'resets last_error' do
-        cache.get invalid_url
-        expect(cache.last_error).to eq '404 Not Found'
-        cache.get url
-        expect(cache.last_error).to be false
+      it 'sets error to the error message' do
+        expect(response.error).to eq '404 Not Found'
       end
     end
   end
@@ -98,12 +86,10 @@ describe WebCache do
   end
 
   describe '#enable' do
-    it "enables cache handling" do
+    it "enables http calls" do
       cache.enable
       expect(cache).to be_enabled
       expect(cache).to receive(:http_get)
-      cache.get url
-      expect(cache).to receive(:load_file_content)
       cache.get url
     end
   end

--- a/webcache.gemspec
+++ b/webcache.gemspec
@@ -19,4 +19,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'runfile-tasks', '~> 0.4'
   s.add_development_dependency 'rspec', '~> 3.4'
   s.add_development_dependency 'simplecov', '~> 0.11'
+  s.add_development_dependency 'byebug', '~> 9.0'
 end


### PR DESCRIPTION
This PR makes several breaking changes:

- HTTP error handling now catches more (all...) errors
- Response is no longer the HTML string. Instead, it is a `Response` object that returns the content in its `#to_s` to ease the transition pains.
- `Cache#last_error` is removed. Instead, it is part of the response object.