### PR TITLE
Allow http to https redirections

### DIFF
--- a/lib/webcache/web_cache.rb
+++ b/lib/webcache/web_cache.rb
@@ -1,6 +1,7 @@
 require 'digest/md5'
 require 'fileutils'
 require 'open-uri'
+require 'open_uri_redirections'
 
 class WebCache
   attr_reader :last_error
@@ -62,7 +63,7 @@ class WebCache
 
   def http_get(url)
     begin
-      Response.new open(url)
+      Response.new open(url, allow_redirections: :all)
     rescue => e
       Response.new error: e.message, base_uri: url, content: e.message
     end

--- a/webcache.gemspec
+++ b/webcache.gemspec
@@ -15,6 +15,8 @@ Gem::Specification.new do |s|
   s.license     = 'MIT'
   s.required_ruby_version = ">= 2.0.0"
 
+  s.add_runtime_dependency 'open_uri_redirections', '~> 0.2'
+
   s.add_development_dependency 'runfile', '~> 0.7'
   s.add_development_dependency 'runfile-tasks', '~> 0.4'
   s.add_development_dependency 'rspec', '~> 3.4'


### PR DESCRIPTION
- Add the `open_uri_redirections` gem in order to allow http to/from https redirects