### PR TITLE
Add support for basic auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,21 @@ cache.cached? 'http://example.com'
 # => true
 ```
 
+
+Basic Authentication and Additional Options
+--------------------------------------------------
+WebCache uses Ruby's [Open URI][1] to download. If you wish to modify 
+the options it uses, simply update the `options` hash.
+
+For example, to use HTTP basic authentication, use something like this:
+
+```ruby
+cache = WebCache.new
+cache.options[:http_basic_authentication] = ["user", "pass123!"]
+response = cache.get 'http://example.com'
+```
+
+
 Response Object
 --------------------------------------------------
 
@@ -118,3 +133,6 @@ puts response
 puts response.error
 # => '404 Not Found'
 ```
+
+
+[1]: http://ruby-doc.org/stdlib-2.0.0/libdoc/open-uri/rdoc/OpenURI/OpenRead.html#method-i-open

--- a/lib/webcache/version.rb
+++ b/lib/webcache/version.rb
@@ -1,3 +1,3 @@
 class WebCache
-  VERSION = "0.2.3"
+  VERSION = "0.3.0"
 end

--- a/lib/webcache/web_cache.rb
+++ b/lib/webcache/web_cache.rb
@@ -44,6 +44,10 @@ class WebCache
     @enabled = false
   end
 
+  def options
+    @options ||= default_open_uri_options
+  end
+
   private
 
   def get_path(url)
@@ -63,7 +67,7 @@ class WebCache
 
   def http_get(url)
     begin
-      Response.new open(url, open_uri_options)
+      Response.new open(url, options)
     rescue => e
       Response.new error: e.message, base_uri: url, content: e.message
     end
@@ -78,7 +82,7 @@ class WebCache
   #    open_uri_redirections gem)
   # 2. Disable SSL verification, otherwise, some https sites that show 
   #    properly in the browser, will return an error.
-  def open_uri_options
+  def default_open_uri_options
     {
       allow_redirections: :all, 
       ssl_verify_mode: OpenSSL::SSL::VERIFY_NONE

--- a/spec/webcache/web_cache_spec.rb
+++ b/spec/webcache/web_cache_spec.rb
@@ -118,4 +118,24 @@ describe WebCache do
     end
   end
 
+  describe '#options' do
+    it "returns a hash with default options" do
+      expected = {
+        allow_redirections: :all, 
+        ssl_verify_mode: OpenSSL::SSL::VERIFY_NONE
+      }
+      expect(cache.options).to eq expected
+    end
+
+    it "allows adding options" do
+      cache.options[:hello] = 'world'
+      expected = {
+        allow_redirections: :all, 
+        ssl_verify_mode: OpenSSL::SSL::VERIFY_NONE,
+        hello: 'world'
+      }
+      expect(cache.options).to eq expected      
+    end
+  end
+
 end


### PR DESCRIPTION
This PR adds support for basic authentication. This is done simply by exposing the options we pass to `Open::URI`.