### PR TITLE
Allow providing cache life as a string

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ expire after 60 minutes. The cache directory will be created as needed.
 You can change these settings on initialization:
 
 ```ruby
-cache = WebCache.new 'tmp/my_cache', 7200
+cache = WebCache.new dir: 'tmp/my_cache', life: '3d'
 response = cache.get 'http://example.com'
 ```
 
@@ -58,6 +58,16 @@ cache = WebCache.new
 cache.dir = 'tmp/my_cache'
 cache.life = 7200 # seconds
 response = cache.get 'http://example.com'
+```
+
+The `life` property accepts any of these formats:
+
+```ruby
+cache.life = 10     # 10 seconds
+cache.life = '20s'  # 20 seconds
+cache.life = '10m'  # 10 minutes
+cache.life = '10h'  # 10 hours
+cache.life = '10d'  # 10 days
 ```
 
 To check if a URL is cached, use the `cached?` method:

--- a/lib/webcache.rb
+++ b/lib/webcache.rb
@@ -1,5 +1,4 @@
 require 'openssl'
 
-require 'webcache/version'
 require 'webcache/web_cache'
 require 'webcache/response'

--- a/lib/webcache/response.rb
+++ b/lib/webcache/response.rb
@@ -17,15 +17,15 @@ class WebCache
     private
 
     def init_with_uri(opts)
-      self.content  = opts.read
-      self.base_uri = opts.base_uri
-      self.error    = nil
+      @content  = opts.read
+      @base_uri = opts.base_uri
+      @error    = nil
     end
 
     def init_with_hash(opts)
-      self.error    = opts[:error]
-      self.base_uri = opts[:base_uri]
-      self.content  = opts[:content]
+      @error    = opts[:error]
+      @base_uri = opts[:base_uri]
+      @content  = opts[:content]
     end
   end
 end

--- a/lib/webcache/web_cache.rb
+++ b/lib/webcache/web_cache.rb
@@ -4,12 +4,12 @@ require 'open-uri'
 require 'open_uri_redirections'
 
 class WebCache
-  attr_reader :last_error
-  attr_accessor :dir, :life
+  attr_reader :last_error, :life
+  attr_accessor :dir
 
-  def initialize(dir='cache', life=3600)
+  def initialize(dir: 'cache', life: '1h')
     @dir = dir
-    @life = life
+    @life = life_to_seconds life
     @enabled = true
   end
 
@@ -20,6 +20,10 @@ class WebCache
     FileUtils.rm path if old? path
 
     get! path, url
+  end
+
+  def life=(new_life)
+    @life = life_to_seconds new_life
   end
 
   def cached?(url)
@@ -77,6 +81,18 @@ class WebCache
 
   def old?(path)
     life > 0 and File.exist?(path) and Time.new - File.mtime(path) >= life
+  end
+
+  def life_to_seconds(arg)
+    arg = arg.to_s
+
+    case arg[-1]
+    when 's'; arg[0..-1].to_i
+    when 'm'; arg[0..-1].to_i * 60
+    when 'h'; arg[0..-1].to_i * 60 * 60
+    when 'd'; arg[0..-1].to_i * 60 * 60 * 24
+    else;     arg.to_i
+    end
   end
 
   # Use a less strict URL retrieval:

--- a/spec/webcache/web_cache_spec.rb
+++ b/spec/webcache/web_cache_spec.rb
@@ -2,7 +2,6 @@ require 'spec_helper'
 require 'fileutils'
 
 describe WebCache do
-  let(:cache) { WebCache.new }
   let(:url) { 'http://example.com' }
 
   before do 
@@ -11,58 +10,66 @@ describe WebCache do
 
   describe '#new' do
     it "sets default properties" do
-      cache = WebCache.new
-      expect(cache.life).to eq 3600
-      expect(cache.dir).to eq 'cache'
+      expect(subject.life).to eq 3600
+      expect(subject.dir).to eq 'cache'
     end
 
-    it "accepts initialization properties" do
-      cache = WebCache.new 'store', 120
-      expect(cache.life).to eq 120
-      expect(cache.dir).to eq 'store'
+    context "with arguments" do
+      subject { described_class.new dir: 'store', life: 120 }
+
+      it "sets its properties" do
+        expect(subject.life).to eq 120
+        expect(subject.dir).to eq 'store'
+      end
     end
   end
 
   describe '#get' do
-    it "skips caching if disabled" do
-      cache.disable
-      cache.get url
-      expect(Dir['cache/*']).to be_empty      
-    end
-
-    it "creates a cache folder" do
-      expect(Dir).not_to exist 'cache'
-      cache.get url
-      expect(Dir).to exist 'cache'
-    end
-
     it "saves a file" do
-      cache.get url
+      subject.get url
       expect(Dir['cache/*']).not_to be_empty
     end
 
     it "downloads from the web" do
-      expect(cache).to receive(:http_get).with(url)
-      cache.get url
+      expect(subject).to receive(:http_get).with(url)
+      subject.get url
     end
 
     it "loads from cache" do
-      cache.get url
-      expect(cache).to be_cached url
-      expect(cache).not_to receive(:http_get).with(url)
-      expect(cache).to receive(:load_file_content)
-      cache.get url
+      subject.get url
+      expect(subject).to be_cached url
+      expect(subject).not_to receive(:http_get).with(url)
+      expect(subject).to receive(:load_file_content)
+      subject.get url
     end
 
     it "returns content from cache" do
-      cache.get url
-      expect(cache).to be_cached url
-      response = cache.get url
+      subject.get url
+      expect(subject).to be_cached url
+      response = subject.get url
       expect(response.content.length).to be > 500
     end
 
+    context "when cache is disabled" do
+      before { subject.disable }
+
+      it "skips caching" do
+        subject.get url
+        expect(Dir['cache/*']).to be_empty      
+      end
+    end
+
+    context "when cache dir does not exist" do
+      before { expect(Dir).not_to exist 'cache' }
+
+      it "creates it" do
+        subject.get url
+        expect(Dir).to exist 'cache'
+      end
+    end
+
     context 'with invalid request' do
-      let(:response) { cache.get 'http://example.com/not_found' }
+      let(:response) { subject.get 'http://example.com/not_found' }
 
       it 'returns the error message' do
         expect(response.content).to eq '404 Not Found'
@@ -74,11 +81,9 @@ describe WebCache do
     end
 
     context "with https" do
-      let(:response) { cache.get 'https://en.wikipedia.org/wiki/HTTPS' }
+      let(:response) { subject.get 'https://en.wikipedia.org/wiki/HTTPS' }
 
-      before do
-        cache.disable
-      end
+      before { subject.disable }
 
       it 'works' do
         expect(response.content.size).to be > 40000
@@ -89,32 +94,32 @@ describe WebCache do
 
   describe '#cached?' do
     it "returns true when url is cached" do
-      cache.get url
-      expect(cache).to be_cached url
+      subject.get url
+      expect(subject).to be_cached url
     end
 
     it "returns false when url is not cached" do
-      expect(cache).not_to be_cached 'http://never.downloaded.com'
+      expect(subject).not_to be_cached 'http://never.downloaded.com'
     end
   end
 
   describe '#enable' do
     it "enables http calls" do
-      cache.enable
-      expect(cache).to be_enabled
-      expect(cache).to receive(:http_get)
-      cache.get url
+      subject.enable
+      expect(subject).to be_enabled
+      expect(subject).to receive(:http_get)
+      subject.get url
     end
   end
 
   describe '#disable' do
     it "disables cache handling" do
-      cache.disable
-      expect(cache).not_to be_enabled
-      expect(cache).to receive(:http_get).exactly(2).times
-      expect(cache).not_to receive(:load_file_content)
-      cache.get url
-      cache.get url
+      subject.disable
+      expect(subject).not_to be_enabled
+      expect(subject).to receive(:http_get).exactly(2).times
+      expect(subject).not_to receive(:load_file_content)
+      subject.get url
+      subject.get url
     end
   end
 
@@ -124,17 +129,45 @@ describe WebCache do
         allow_redirections: :all, 
         ssl_verify_mode: OpenSSL::SSL::VERIFY_NONE
       }
-      expect(cache.options).to eq expected
+      expect(subject.options).to eq expected
     end
 
     it "allows adding options" do
-      cache.options[:hello] = 'world'
+      subject.options[:hello] = 'world'
+
       expected = {
         allow_redirections: :all, 
         ssl_verify_mode: OpenSSL::SSL::VERIFY_NONE,
         hello: 'world'
       }
-      expect(cache.options).to eq expected      
+      expect(subject.options).to eq expected      
+    end
+  end
+
+  describe '#life=', :focus do    
+    it "handles plain numbers" do
+      subject.life = 11
+      expect(subject.life).to eq 11
+    end
+
+    it "handles 11s as seconds" do
+      subject.life = '11s'
+      expect(subject.life).to eq 11
+    end
+
+    it "handles 11m as minutes" do
+      subject.life = '11m'
+      expect(subject.life).to eq 11 * 60
+    end
+
+    it "handles 11h as hours" do
+      subject.life = '11h'
+      expect(subject.life).to eq 11 * 60 * 60
+    end
+
+    it "handles 11d as days" do
+      subject.life = '11d'
+      expect(subject.life).to eq 11 * 60 * 60 * 24
     end
   end
 

--- a/webcache.gemspec
+++ b/webcache.gemspec
@@ -18,9 +18,9 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency 'open_uri_redirections', '~> 0.2'
 
-  s.add_development_dependency 'runfile', '~> 0.9'
+  s.add_development_dependency 'runfile', '~> 0.10'
   s.add_development_dependency 'runfile-tasks', '~> 0.4'
   s.add_development_dependency 'rspec', '~> 3.4'
-  s.add_development_dependency 'simplecov', '~> 0.14'
-  s.add_development_dependency 'byebug', '~> 9.0'
+  s.add_development_dependency 'simplecov', '~> 0.15'
+  s.add_development_dependency 'byebug', '~> 10.0'
 end


### PR DESCRIPTION
- Allow using `10s`, `10m`, `10h` and `10d` as values for `cache.life`
- Change initializer to require keyword arguments instead of positional. This is not backwards compatible