### PR TITLE
Fix base_uri when its a broken link

### DIFF
--- a/lib/webcache/cache_operations.rb
+++ b/lib/webcache/cache_operations.rb
@@ -92,6 +92,7 @@ class WebCache
     def http_get(url)
       Response.new open(url, options)
     rescue => e
+      url = URI.parse url
       Response.new error: e.message, base_uri: url, content: e.message
     end
 


### PR DESCRIPTION
When the page is not found, the `base_uri` parameter was a string, as opposed to a `URI::HTTP` in valid cases. This PR makes it consistent by converting the URL to `URI::HTTP` also for broken pages.

Hopefully this does not have any negative side effects.