### PR TITLE
Replace %20 with +

### DIFF
--- a/lib/webcache/cache_operations.rb
+++ b/lib/webcache/cache_operations.rb
@@ -15,6 +15,8 @@ class WebCache
     end
 
     def get(url, force: false)
+      url = url.gsub(/%20/, '+')
+      
       return http_get url unless enabled?
 
       path = get_path url

--- a/spec/webcache/web_cache_spec.rb
+++ b/spec/webcache/web_cache_spec.rb
@@ -95,6 +95,18 @@ describe WebCache do
         expect(response.error).to be nil
       end
     end
+
+    context "when a url contains %20" do
+      let(:url)      { 'http://software-engineering-handbook.com/Handbook/Video%20Series' }
+      let(:expected) { 'http://software-engineering-handbook.com/Handbook/Video+Series' }
+      let(:response) { subject.get url }
+      
+      it "substitutes it with +" do
+        expect(response.content.size).to be > 1000
+        expect(response.error).to be nil
+        expect(response.base_uri.to_s).to eq expected
+      end
+    end
   end
 
   describe '#cached?' do


### PR DESCRIPTION
### ⚠️ HOLD

Waiting with the merge, maybe [this SO question][1] will provide a better option.

in addition, this is not a good solution, as in some cases this replacement is not desired.
Need to only try this hack in case we fail to get with the `%20`.

---

Something behaves weirdly (in curl and in Ruby HTTP client) on this page:
<http://software-engineering-handbook.com/Handbook/Video%20Series>



Test case:

```ruby
require 'open-uri'

base = "http://software-engineering-handbook.com/Handbook"

puts "===> PASS: URI Open +"
result = open "#{base}/Video+Series"
p result.status

puts "===> PASS: Curl +"
puts `curl -LIsS "#{base}/Video+Series" | grep HTTP`

puts "===> PASS: Curl %20"
puts `curl -LIsS "#{base}/Video%20Series" | grep HTTP`

puts "===> FAIL: URI Open %20"
begin
  result = open "#{base}/Video%20Series"
  p result.status
rescue => e
  puts "#{e.class} #{e.message}"
end
```

[1]: https://stackoverflow.com/questions/59514020/openuri-fails-to-follow-urls-that-have-20