### PR TITLE
Switch to http gem

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,5 @@
 /gems
 /Gemfile.lock
 /.yardoc
+/debug.rb
 *.gem

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ rvm:
 - "2.4"
 - "2.5"
 - "2.6"
-- "2.7"
+# - "2.7"  # Failing for now, due to github.com/httprb/http/issues/582
 
 before_install:
 - gem install bundler

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,7 @@
 source "https://rubygems.org"
 
 gem 'byebug'
+gem 'lp'
 gem 'rspec'
 gem 'runfile'
 gem 'runfile-tasks'

--- a/README.md
+++ b/README.md
@@ -147,18 +147,37 @@ cache = WebCache.new
 response = cache.get 'http://example.com', force: true
 ```
 
-Basic Authentication and Additional Options
+Authentication
 --------------------------------------------------
-WebCache uses Ruby's [Open URI][1] to download. If you wish to modify 
-the options it uses, simply update the `options` hash.
 
-For example, to use HTTP basic authentication, use something like this:
+To configure an authentication header, use the `auth` option. Similarly to
+the other options, this can be set directly on the static class, on instance
+initialization, or later on the instance:
 
 ```ruby
+cache = WebCache.new auth: '...'
+cache.get 'http://example.com'      # authenticated
+
 cache = WebCache.new
-cache.options[:http_basic_authentication] = ["user", "pass123!"]
-response = cache.get 'http://example.com'
+cache.auth = '...'
+cache.get 'http://example.com'      # authenticated
+
+WebCache.auth = '...'
+WebCache.get 'http://example.com'   # authenticated
 ```
+
+For basic authentication, provide a hash:
+
+```ruby
+cache = WebCache.new auth: { user: 'user', pass: 's3cr3t' }
+```
+
+For other authentication headers, simply provide the header string:
+
+```ruby
+cache = WebCache.new auth: "Bearer t0k3n"
+```
+
 
 
 Response Object
@@ -177,6 +196,13 @@ the same content.
 
 In case of an error, this contains the error message, `nil` otherwise.
 
+### `response.code`
+
+Contains the HTTP code, or `nil` if there was a non-HTTP error.
+
+### `response.success?`
+
+A convenience method, returns true if `error` is empty.
 
 ### `response.base_uri`
 

--- a/Runfile
+++ b/Runfile
@@ -12,3 +12,5 @@ help   "Run interactive console"
 action :console, :c do
   run "bundle exec bin/console"
 end
+
+require_relative 'debug' if File.exist? 'debug.rb'

--- a/lib/webcache.rb
+++ b/lib/webcache.rb
@@ -4,3 +4,9 @@ require 'webcache/polyfills'
 require 'webcache/cache_operations'
 require 'webcache/response'
 require 'webcache/web_cache'
+
+if ENV['BYEBUG']
+  require 'byebug'
+  require 'lp'
+end
+

--- a/lib/webcache/response.rb
+++ b/lib/webcache/response.rb
@@ -1,10 +1,10 @@
 class WebCache
   class Response
-    attr_accessor :error, :base_uri, :content
+    attr_accessor :error, :base_uri, :content, :code
 
     def initialize(opts={})
-      if opts.respond_to?(:read) && opts.respond_to?(:base_uri)
-        init_with_uri opts
+      if opts.is_a? HTTP::Response
+        init_with_http_response opts
       elsif opts.is_a? Hash
         init_with_hash opts
       end
@@ -14,18 +14,29 @@ class WebCache
       content
     end
 
-    private
+    def success?
+      !error
+    end
 
-    def init_with_uri(opts)
-      @content  = opts.read
-      @base_uri = opts.base_uri
-      @error    = nil
+  private
+
+    def init_with_http_response(response)
+      @base_uri = response.uri
+      @code = response.code
+      if response.status.success?
+        @content  = response.to_s
+        @error    = nil
+      else
+        @content  = response.status.to_s
+        @error    = response.status.to_s
+      end
     end
 
     def init_with_hash(opts)
       @error    = opts[:error]
       @base_uri = opts[:base_uri]
       @content  = opts[:content]
+      @code     = opts[:code]
     end
   end
 end

--- a/spec/webcache/response_spec.rb
+++ b/spec/webcache/response_spec.rb
@@ -5,9 +5,10 @@ describe WebCache::Response do
     context "with hash" do
       let :response do
         described_class.new({ 
-          error: 'problemz', 
-          base_uri: 'sky.net', 
-          content: 'robots' 
+          error: 'problemz',
+          base_uri: 'sky.net',
+          content: 'robots',
+          code: 200
         })
       end
 
@@ -22,34 +23,58 @@ describe WebCache::Response do
       it "sets content" do
         expect(response.content).to eq 'robots'
       end
+
+      it "sets code" do
+        expect(response.code).to eq 200
+      end
     end
 
-    context "with open uri" do
-      let :response do
-        described_class.new OpenStruct.new base_uri: 'sky.net', read: 'robots'
-      end
+    context "with HTTP response" do
+      let(:http_response) { HTTP.follow.get "http://example.com" }
+      let(:response) { described_class.new http_response }
       
       it "sets error" do
         expect(response.error).to be nil
       end
 
       it "sets base_uri" do
-        expect(response.base_uri).to eq 'sky.net'
+        expect(response.base_uri.to_s).to eq 'http://example.com/'
       end
 
       it "sets content" do
-        expect(response.content).to eq 'robots'
+        expect(response.content).to match 'Example Domain'
+      end
+
+      it "sets code" do
+        expect(response.code).to eq 200
       end
     end
   end
 
   describe '#to_s' do
-    let :response do
-      described_class.new content: 'robots'
-    end
+    let(:response) { described_class.new content: 'robots' }
 
     it "returns the content" do
       expect(response.to_s).to eq 'robots'
     end
   end
+
+  describe '#success?' do
+    context "when there was an error" do
+      let(:response) { described_class.new error: 'robots' }
+
+      it "returns false" do
+        expect(response.success?).to be false
+      end
+    end
+
+    context "when there was no error" do
+      let(:response) { described_class.new content: 'robots' }
+
+      it "returns true" do
+        expect(response.success?).to be true
+      end
+    end
+  end
+
 end

--- a/spec/webcache/web_cache_spec.rb
+++ b/spec/webcache/web_cache_spec.rb
@@ -114,11 +114,11 @@ describe WebCache do
       let(:response) { subject.get 'http://not-a-uri' }
 
       it 'returns the error message' do
-        expect(response.content).to match 'failure in name resolution'
+        expect(response.content).to match 'failed to connect'
       end
 
       it 'sets error to the error message' do
-        expect(response.error).to match 'failure in name resolution'
+        expect(response.error).to match 'failed to connect'
       end
     end
 

--- a/webcache.gemspec
+++ b/webcache.gemspec
@@ -16,5 +16,5 @@ Gem::Specification.new do |s|
   s.license     = 'MIT'
   s.required_ruby_version = ">= 2.3.0"
 
-  s.add_runtime_dependency 'open_uri_redirections', '~> 0.2'
+  s.add_runtime_dependency 'http', '~> 4.2'
 end


### PR DESCRIPTION
- Switch from URI Open to HTTP gem, due to some subtle issues with Open URI strictness.
- Add HTTP code to the response object.
- Add `response.success?` convenience method.
- Remove `WebCache#options`.
- Add ability to authenticate with basic authentication, or another authentication method - as provided by the HTTP gem.